### PR TITLE
Added support for BigQuery Geography column data type

### DIFF
--- a/target_bigquery/schema.py
+++ b/target_bigquery/schema.py
@@ -221,6 +221,8 @@ def define_schema(field, name, required_fields=None):
             schema_type = "date"
         elif f == "time":
             schema_type = "time"
+        elif format == "geography":
+            schema_type = "GEOGRAPHY"
         else:
             schema_type = field_type
 


### PR DESCRIPTION
Allows users to supply a 'geography' format in their jsonschema to create a BigQuery geography column.

(Not sure if you guys are interested in added this functionality, as it doesn't follow the jsonschema spec for the "format" attribute)