### PR TITLE
Feature/improve schema logging

### DIFF
--- a/target_bigquery/processhandler.py
+++ b/target_bigquery/processhandler.py
@@ -94,6 +94,8 @@ class BaseProcessHandler(object):
         self.bq_schema_dicts[msg.stream] = self._build_bq_schema_dict(schema)
         self.bq_schemas[msg.stream] = schema
 
+        self.logger.info(f"{msg.stream} BigQuery schema {schema}")
+
         yield from ()
 
     def on_stream_end(self):


### PR DESCRIPTION
I was running into some issues where taps did not provide good schemas, which unfortunately lead to exceptions in target-bigquery. These were hard to debug at times, because it was difficult to pinpoint what exactly went wrong. Adding the following log statements helped my debugging of these problems a lot. 

Note for reviewers: 
- Python is not my home turf, I used f-string for formatting log statements, not sure if that's the right way to go
- I chose info log level for both statements. 1) The JSON schema is logged at info level as well, so logging the BQ schema at info felt right. 2) failing to format the record crashes the target always, so logging it at info level felt right, so that users would not have to re-run it with debug level