### PR TITLE
Add handling of common non alphanumeric values in column names

### DIFF
--- a/target_bigquery/schema.py
+++ b/target_bigquery/schema.py
@@ -62,10 +62,17 @@ def create_valid_bigquery_field_name(field_name):
 
     cleaned_up_field_name = ""
 
+    cleanup_mapping = {
+        "+": "plus_",
+        "-": "minus_"
+    }
+
     # if char is alphanumeric (either letters or numbers), append char to our string
     for char in field_name:
         if char.isalnum():
             cleaned_up_field_name += char
+        elif char in cleanup_mapping.keys():
+            cleaned_up_field_name += cleanup_mapping[char]
         else:
             # otherwise, replace it with underscore
             cleaned_up_field_name += "_"


### PR DESCRIPTION
Related to an issue on https://github.com/MeltanoLabs/tap-github/issues/64

We would like to suggest a simple mapping from +/- to plus/minus when updating column names to make them safe to use for BigQuery while conserving their meaning.

Alternatively, we could only do that change for "+".