### PR TITLE
Use compatible requirement for bigquery dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 singer-python~=5.12.1
-google-cloud-bigquery==2.26.0
+google-cloud-bigquery~=2.26.0
 jsonschema~=2.6.0
 setuptools~=60.3.1


### PR DESCRIPTION
This PR updates the bigquery dependency to align with the other dependencies ([compatible release specifier](https://peps.python.org/pep-0440/#compatible-release)) for the version requirement.

Pinning the version can cause dependency resolution to fail with projects that have multiple libraries referencing bigquery or when run on machines having certain system architectures (some versions might not have a package prebuilt).