### PR TITLE
Add deduplication option

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ sample [target-config.json](/sample_config/target-config-exchange-rates-api.json
     * `truncate`: Deleting all previous rows and uploading the new ones to the table
     * `incremental`: **Upserting** new rows into the table, using the **primary key** given by the tap connector
       (if it finds an old row with same key, updates it. Otherwise it inserts the new row)
-- WARNING: We do not recommend using `incremental` option (which uses `MERGE` SQL statement). It might result in loss of production data, because historical records get updated. Instead, we recommend using the `append` replication method, which will preserve historical data. 
+ - WARNING: We do not recommend using `incremental` option (which uses `MERGE` SQL statement). It might result in loss of production data, because historical records get updated. Instead, we recommend using the `append` replication method, which will preserve historical data. 
 - There's also the option to set an additional parameter `deduplication_property` in order to deduplicate values. Based on an attribute (Typically a timestamp), a query will run before the loading part to BigQuery, removing all duplicates.
   - And besides that, the possibility  to choose the order of this parameter with `deduplication_order` with:
     * **DESC**: Default option. Keeps the one with the bigger deduplication_property or a random element between those who have the bigger one.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,13 @@ sample [target-config.json](/sample_config/target-config-exchange-rates-api.json
     * `truncate`: Deleting all previous rows and uploading the new ones to the table
     * `incremental`: **Upserting** new rows into the table, using the **primary key** given by the tap connector
       (if it finds an old row with same key, updates it. Otherwise it inserts the new row)
- - WARNING: We do not recommend using `incremental` option (which uses `MERGE` SQL statement). It might result in loss of production data, because historical records get updated. Instead, we recommend using the `append` replication method, which will preserve historical data. 
+- WARNING: We do not recommend using `incremental` option (which uses `MERGE` SQL statement). It might result in loss of production data, because historical records get updated. Instead, we recommend using the `append` replication method, which will preserve historical data. 
+- There's also the option to set an additional parameter `deduplication_property` in order to deduplicate values. Based on an attribute (Typically a timestamp), a query will run before the loading part to BigQuery, removing all duplicates.
+  - And besides that, the possibility  to choose the order of this parameter with `deduplication_order` with:
+    * **DESC**: Default option. Keeps the one with the bigger deduplication_property or a random element between those who have the bigger one.
+    * **ASC**: Keeps the one with the smaller deduplication_property or a random element between those who have the bigger one.
+
+
 
 Sample **target-config.json** file:
 

--- a/target_bigquery/__init__.py
+++ b/target_bigquery/__init__.py
@@ -75,6 +75,10 @@ def main():
     validate_records = config.get("validate_records", True)
     add_metadata_columns = config.get("add_metadata_columns", True)
 
+    # deduplication arguments
+    deduplication_property = config.get("deduplication_property", "")
+    deduplication_order = config.get("deduplication_order", "DESC")
+
     # we can pass merge state option via CLI param
     merge_state_messages_cli = flags.merge_state_messages
 
@@ -126,7 +130,9 @@ def main():
             table_suffix=table_suffix,
             add_metadata_columns=add_metadata_columns,
             table_configs=table_configs,
-            max_cache=max_cache
+            max_cache=max_cache,
+            deduplication_property=deduplication_property,
+            deduplication_order=deduplication_order
         )
 
         # write a state file


### PR DESCRIPTION
# Description of change
It may occur for some taps, such as the **DynamoDB** one (using DynamoDB Streams) that duplicates are generated. To solve this, based on an attribute (Typically a timestamp), a query will run before the loading part to BQ, removing all duplicates.

# Manual QA steps
In order to run the deduplication, we need to specify as environment variables, the following attributes:

 - `deduplication_property`: we need to specify the attribute that we want to deduplicate on (Tipically a timestamp).
In case of having a duplicate, the query is going to keep the one, by default, with the bigger `deduplication_property` or a random element between those who have the bigger one.
But we can also modify the order, if for example we want to keep the smaller one.
    - `deduplication_order`: 
      * **DESC**: Default option. Keeps the one with the bigger deduplication_property or a random element between those who have the bigger one.
      * **ASC**: Keeps the one with the smaller deduplication_property or a random element between those who have the bigger one.


# Additional info
For example, let's say we have the following data coming from the tap:


```
#_id, name, email, city, date
#1, Mike, NULL, NULL, 2022-07-19 09:00:00
#1, Mike, mike@mike.com, NULL, 2022-07-19 09:10:00
#2, Scopely, scopely@scopely.com, NULL, 2022-07-19 09:05:00
#1, Mike, mike@mike.com, Barcelona, 2022-07-19 09:15:00
```
In this case, being `date` as deduplication_property and deduplication_order by default (DESC) we would have:

```
#_id, name, email, city, date
#1, Mike, mike@mike.com, Barcelona, 2022-07-19 09:15:00
#2, Scopely, scopely@scopely.com, NULL, 2022-07-19 09:05:00
```

If we set the deduplication_order to ASC, we would have:

```
#_id, name, email, city, date
#1, Mike, NULL, NULL, 2022-07-19 09:00:00
#2, Scopely, scopely@scopely.com, NULL, 2022-07-19 09:05:00
```


